### PR TITLE
etcd and flanneld with certificates

### DIFF
--- a/templates/apiserver.j2
+++ b/templates/apiserver.j2
@@ -1,7 +1,7 @@
 #FILE:  apiserver
 KUBE_API_ADDRESS="--address=0.0.0.0"
 #KUBE_API_PORT="--port=8080"
-KUBE_ETCD_SERVERS="--etcd_servers=http://{{ masterip }}:4001"
+KUBE_ETCD_SERVERS="--etcd-cafile=/etc/kubernetes/certs/ca.crt --etcd-certfile=/etc/kubernetes/certs/{{item}}.crt --etcd-keyfile=/etc/kubernetes/certs/{{item}}.key  --etcd_servers=https://{{ masterip }}:4001"
 KUBELET_PORT="--kubelet_port=10250"
 KUBE_SERVICE_ADDRESSES="--portal_net=10.254.0.0/16"
 KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota"

--- a/templates/etcd.conf.j2
+++ b/templates/etcd.conf.j2
@@ -1,5 +1,13 @@
 #FILE: etcd.conf
 ETCD_NAME=default
 ETCD_DATA_DIR="/var/lib/etcd/default.etcd"
-ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:4001"
-ETCD_ADVERTISE_CLIENT_URLS="http://localhost:2379,http://localhost:4001"
+ETCD_LISTEN_CLIENT_URLS="https://0.0.0.0:4001,https://{{ masterip }}:4001"
+ETCD_ADVERTISE_CLIENT_URLS="https://localhost:2379,https://localhost:4001,https://{{ masterip   }}:4001"
+ETCD_CLIENT_CERT_AUTH="true"
+ETCD_TRUSTED_CA_FILE="/etc/kubernetes/certs/ca.crt"
+ETCD_CERT_FILE="/etc/kubernetes/certs/{{item}}.crt"
+ETCD_KEY_FILE="/etc/kubernetes/certs/{{item}}.key"
+ETCD_PEER_CLIENT_CERT_AUTH="true"
+ETCD_PEER_TRUSTED_CA_FILE="/etc/kubernetes/certs/ca.crt"
+ETCD_PEER_CERT_FILE="/etc/kubernetes/certs/{{item}}.crt"
+ETCD_PEER_KEY_FILE="/etc/kubernetes/certs/{{item}}.key"

--- a/templates/flanneld.j2
+++ b/templates/flanneld.j2
@@ -1,5 +1,7 @@
 #FILE: flanneld
-FLANNEL_ETCD="http://{{ masterip }}:4001"
+FLANNEL_ETCD="https://{{ masterip }}:4001"
 FLANNEL_ETCD_KEY="/coreos.com/network"
+FLANNELD_ETCD_CAFILE="/etc/kubernetes/certs/ca.crt"
+FLANNELD_ETCD_CERTFILE="/etc/kubernetes/certs/{{item}}.crt"
+FLANNELD_ETCD_KEYFILE="/etc/kubernetes/certs/{{item}}.key"
 #FLANNEL_OPTIONS=""
-EOF


### PR DESCRIPTION
Hi James! 

I've modified the configuration files for etcd, flanneld, and apiserver so that etcd can use certificates.
It's necessary to have etcd listening on the public interface so that the nodes can query it, and then flannel will be able to start.
Now if you want to issue any etcdctl command to query the registry, you have to use the syntax:

$ etcdctl --cert-file /etc/kubernetes/certs/XXXXX.crt --key-file /etc/kubernetes/certs/XXXXX.key --ca-file /etc/kubernetes/certs/ca.crt.

And from any of the nodes, you can use: 

$ etcdctl --endpoint https://{{ masterip }}:4001 --cert-file /etc/kubernetes/certs/XXXXX.crt --key-file /etc/kubernetes/certs/XXXXX.key --ca-file /etc/kubernetes/certs/ca.crt.
